### PR TITLE
Install openjdk-7-jre on all environments

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,10 +5,7 @@ KUROMOJI_VERSION=2.5.0
 
 sudo apt-get update
 sudo apt-get upgrade
-
-if type java > /dev/null 2&>1; then
-  sudo apt-get install -y openjdk-7-jre
-fi
+sudo apt-get install -y openjdk-7-jre
 
 sudo wget -O /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo dpkg -i /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb


### PR DESCRIPTION
## WHY

Deploy of https://app.wercker.com/#build/561326a49142f888090d440d raises the following error:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/elasticsearch/plugins/PluginManager : Unsupported major.minor version 51.0
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:643)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:277)
    at java.net.URLClassLoader.access$000(URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:212)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:323)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:268)
Could not find the main class: org.elasticsearch.plugins.PluginManager. Program will exit.
```

I found that Elasticsearch >= 1.3 requires Java 7 at this discussion: [amazon web services - Issues after Elasticsearch 1.3.2 upgrade - Stack Overflow](http://stackoverflow.com/questions/25518908/issues-after-elasticsearch-1-3-2-upgrade). Base box uses Java 6.
## WHAT

Install Java 7 (openjdk-7-jre) in this box.
