### PR TITLE
Build box from plain Ubuntu image

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -4,8 +4,8 @@ ELASTICSEARCH_VERSION=1.5.2
 KUROMOJI_VERSION=2.5.0
 
 sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install -y openjdk-7-jre
+sudo apt-get -y upgrade
+sudo apt-get install -y openjdk-7-jre wget
 
 sudo wget -O /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo dpkg -i /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,6 +1,5 @@
 name: kuromoji-elasticsearch
 version: 0.0.7
-inherits: wercker/ubuntu12.04-webessentials@0.0.3
 type: service
 platform: ubuntu@12.04
 description: elasticsearch with kuromoji plugin


### PR DESCRIPTION
## WHY

Unfortunally deploy of https://app.wercker.com/#build/561330f59142f888090d5b80 fails again... It seems that installed Java 6 in webessential box conflicts Java 7. We don't need Java 6 completely.

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/elasticsearch/plugins/PluginManager : Unsupported major.minor version 51.0
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:643)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:277)
    at java.net.URLClassLoader.access$000(URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:212)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:323)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:268)
Could not find the main class: org.elasticsearch.plugins.PluginManager. Program will exit.
```
## WHAT

Build box from plain Ubuntu 12.04 image
