### PR TITLE
Start Elasticsearch service

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -12,3 +12,4 @@ sudo dpkg -i /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo sed -i 's/# http.enabled: false/http.enabled: true/g' /etc/elasticsearch/elasticsearch.yml
 sudo sed -i 's/# network.host: 192.168.0.1/network.host: $$HOST$$/g' /etc/elasticsearch/elasticsearch.yml
 sudo /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-kuromoji/$KUROMOJI_VERSION
+sudo service elasticsearch restart


### PR DESCRIPTION
## WHY

Without `sudo service elasticsearch start`, Elasticsearch service does not start up. It causes the below error:

```
     Faraday::ConnectionFailed:
       Connection refused - connect(2) for "10.0.3.133" port 9200 (http://10.0.3.133:9200)
```
## WHAT

Start Elasticsearch service explicitly
