### PR TITLE
Update comment out notation

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -9,7 +9,7 @@ sudo apt-get install -y openjdk-7-jre wget
 
 sudo wget -O /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo dpkg -i /tmp/elasticsearch-$ELASTICSEARCH_VERSION.deb
-sudo sed -i 's/# http.enabled: false/http.enabled: true/g' /etc/elasticsearch/elasticsearch.yml
-sudo sed -i 's/# network.host: 192.168.0.1/network.host: $$HOST$$/g' /etc/elasticsearch/elasticsearch.yml
+sudo sed -i 's/#http.enabled: false/http.enabled: true/g' /etc/elasticsearch/elasticsearch.yml
+sudo sed -i 's/#network.host: 192.168.0.1/network.host: $$HOST$$/g' /etc/elasticsearch/elasticsearch.yml
 sudo /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-kuromoji/$KUROMOJI_VERSION
 sudo service elasticsearch restart

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,5 +1,5 @@
 name: kuromoji-elasticsearch
-version: 0.0.8
+version: 0.0.9
 type: service
 platform: ubuntu@12.04
 description: elasticsearch with kuromoji plugin


### PR DESCRIPTION
Elasticsearch 1.0.1 uses:

```
# http.enabled: false
# network.host: 192.168.0.1
```

However, Elasticsearch 1.5.2 uses:

```
#http.enabled: false
#network.host: 192.168.0.1
```

So we need to update replace script
